### PR TITLE
remove SyntaxWarnings and DeprecationWarnings

### DIFF
--- a/dumper.py
+++ b/dumper.py
@@ -22,7 +22,7 @@ def dump_to_file(agent, base, size, error, directory):
 def splitter(agent,base,size,max_size,error,directory):
         times = size//max_size
         diff = size % max_size
-        if diff is 0:
+        if diff == 0:
             logging.debug("Number of chunks:"+str(times+1))
         else:
             logging.debug("Number of chunks:"+str(times))
@@ -34,6 +34,6 @@ def splitter(agent,base,size,max_size,error,directory):
                 dump_to_file(agent, cur_base, max_size, error, directory)
                 cur_base = cur_base + max_size
 
-        if diff is not 0:
+        if diff != 0:
             # logging.debug("Save bytes: "+str(hex(cur_base))+" till "+str(hex(cur_base+diff)))
             dump_to_file(agent, cur_base, diff, error, directory)

--- a/fridump3.py
+++ b/fridump3.py
@@ -125,7 +125,7 @@ rpc.exports = {
 script.on("message", on_message)
 script.load()
 
-agent = script.exports
+agent = script.exports_sync
 ranges = agent.enumerate_ranges(PERMS)
 
 if arguments.max_size is not None:


### PR DESCRIPTION
Hey, 

this pull request removes warnings regarding SyntaxWarnings and a DeprecationWarning, which is caused since agent = script.exports will get async in the future. We therefore exchange it with agent = script.exports_sync.

